### PR TITLE
dry run output: Println -> Printf as intended

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -73,7 +73,7 @@ func (e fsResizer) DepResizer() (Resizer, error) {
 
 func (e fsResizer) Resize() error {
 	if *dry {
-		fmt.Println("[dry-run] would've run %v %v", e.cmd.Path, e.cmd.Args)
+		fmt.Printf("[dry-run] would've run %v %v\n", e.cmd.Path, e.cmd.Args)
 		return nil
 	}
 	out, err := e.cmd.CombinedOutput()


### PR DESCRIPTION
Output before:

```
~/go/bin(master*) » sudo ./embiggen-disk -dry-run /
[dry-run] would've run sfdisk -f to set new partition table
[dry-run] would've run %v %v /usr/bin/btrfs [btrfs filesystem resize max /]
No changes made.
```

Output after:

```
~/go/bin(master*) » sudo ./embiggen-disk -dry-run /
[dry-run] would've run sfdisk -f to set new partition table
[dry-run] would've run /usr/bin/btrfs [btrfs filesystem resize max /]
No changes made.
```