### PR TITLE
Fix /sbin/sfdisk hanging indefinitely

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -192,6 +192,7 @@ func TestInQemu(t *testing.T) {
 		"-monitor", "unix:"+monSockPath+",server,nowait",
 		"-device", "virtio-net,netdev=net0",
 		"-netdev", "user,id=net0,guestfwd=tcp:10.0.2.100:1234-tcp:"+ln.Addr().String(),
+		"-device", "virtio-rng-pci",
 		"-device", "virtio-serial",
 		"-device", "virtio-scsi-pci,id=scsi",
 		"-kernel", kernelPath,


### PR DESCRIPTION
Due to a kernel bug
(https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=897572#82) reading
from /dev/urandom can block. `sfdisk` appears to read from /dev/urandom
and would hang indefinitely due to this bug. This workaround generates
entropy so crng init can complete and reading from /dev/urandom will
unblock.