### PR TITLE
Fix resizing of /dev/mmcblk0pN paths

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -67,7 +67,9 @@ func (e fsResizer) DepResizer() (Resizer, error) {
 	if dev == "/dev/root" {
 		return nil, errors.New("unexpected device /dev/root from statFS")
 	}
-	if (strings.HasPrefix(dev, "/dev/sd") || strings.HasPrefix(dev, "/dev/nvme")) &&
+	if (strings.HasPrefix(dev, "/dev/sd") ||
+		strings.HasPrefix(dev, "/dev/mmcblk") ||
+		strings.HasPrefix(dev, "/dev/nvme")) &&
 		devEndsInNumber(dev) {
 		vlogf("fsResizer.DepResizer: returning partitionResizer(%q)", dev)
 		return partitionResizer(dev), nil

--- a/part.go
+++ b/part.go
@@ -51,6 +51,11 @@ func diskDev(partDev string) string {
 	if strings.HasPrefix(partDev, "/dev/sd") {
 		return strings.TrimRight(partDev, "0123456789")
 	}
+	if strings.HasPrefix(partDev, "/dev/mmcblk") {
+		v := strings.TrimRight(partDev, "0123456789")
+		v = strings.TrimSuffix(v, "p")
+		return v
+	}
 	if strings.HasPrefix(partDev, "/dev/nvme") {
 		chopP := regexp.MustCompile(`p\d+$`)
 		if !chopP.MatchString(partDev) {


### PR DESCRIPTION
Adds support for `/dev/mmcblk0pN` i.e. /dev/mmcblk0p1

```
Changes made:
  * partition /dev/mmcblk0p3: before: 36792320 sectors, after: 122636288 sectors
  * ext4 filesystem at /mnt/persist: before: 4460986 blocks, after: 15023331 blocks

```