### PR TITLE
fs: further try to find the device associated with the mountpoint

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -135,7 +135,12 @@ func statFS(mnt string) (fs fsStat, err error) {
 			if fs.dev == "/dev/root" {
 				dev, err := findDevRoot()
 				if err != nil {
-					return fs, fmt.Errorf("failed to map /dev/root to real device: %v", err)
+					// last-ditch recovery
+					out, err := exec.Command("findmnt", "-n", "-o", "SOURCE", mnt).Output()
+					if err != nil || len(out) < 2 {
+						return fs, fmt.Errorf("failed to map /dev/root to real device: %v", err)
+					}
+					dev = strings.Split(string(out), "\n")[0]
 				}
 				fs.dev = dev
 			}


### PR DESCRIPTION
The heuristic to find the path to the device node where the filesystem
is mounted, sometime fails to find the device node, especially for cases
where /dev/root is mounted on /. We have code to handle that case, but
it may still fail (for reasons that we could not fathom... sigh...)

Add a last-ditch tentative by calling to an external tool, findmnt,
which very purpose is exactly to provide information about mountpoints.

In our case, we just need the path to the device node (-o SOURCE), and
we do not need the header line (-n). We also assume that, if findmnt did
find something of interest to us, it will return something that is at
least 2 bytes long (counting the trailing \n).